### PR TITLE
Modify dependencies in default.opam.locked (#33)

### DIFF
--- a/.github/workflows/build-notebook.yml
+++ b/.github/workflows/build-notebook.yml
@@ -27,7 +27,7 @@ jobs:
       hadolint-ignore: "DL3008,DL3016,DL3006"
       image-name: ${{ inputs.image-name }}
       image-custom-tag: ${{ inputs.image-custom-tag }}
-      extra-build-args: 
+      extra-build-args: |
         NOTEBOOK_MAINTAINER=aphp
         BASE_IMAGE=${{ inputs.base-notebook-image }}
         NOTEBOOK_IMAGE=${{ inputs.notebook-image }}
@@ -42,3 +42,5 @@ jobs:
         CVE-2025-68121
       trivy-ignore-license-ids: |
         WTFPL
+      trivy-ignore-files: |
+        /opt/conda/lib/R/library/gargle/extdata/fake_service_account.json

--- a/.github/workflows/ci-eds-notebook.yaml
+++ b/.github/workflows/ci-eds-notebook.yaml
@@ -51,7 +51,18 @@ jobs:
       image-custom-tag: "x86_64-ubuntu-24.04-nightly"
       base-notebook-image: *base-notebook-image
       notebook-image: *notebook-image
-
+      
+  eds-ocaml-notebook-snapshot:
+    if: ${{ needs.eds-base-notebook-snapshot.result == 'success' }}
+    uses: "./.github/workflows/build-notebook.yml"
+    needs: "eds-base-notebook-snapshot"
+    with:
+      dockerfile-path: &o-docker-path "eds-ocaml-notebook/Dockerfile"
+      image-name: &o-image-name "ghcr.io/aphp/base-ocaml-notebook"
+      image-custom-tag: "x86_64-ubuntu-24.04-snapshot"
+      base-notebook-image: &o-base-notebook-image "ghcr.io/aphp/base-eds-notebook:x86_64-ubuntu-24.04-snapshot"
+      notebook-image:  &o-notebook-image "EDS-OCAML-NOTEBOOK"
+      
   eds-ocaml-notebook-dev:
     if: ${{ needs.eds-base-notebook-dev.result == 'success' }}
     uses: "./.github/workflows/build-notebook.yml"
@@ -71,7 +82,7 @@ jobs:
       dockerfile-path: *o-docker-path
       image-name: *o-image-name 
       image-custom-tag: "x86_64-ubuntu-24.04-nightly"
-      base-notebook-image: *o-base-notebook-image
+      base-notebook-image: &o-base-notebook-image "ghcr.io/aphp/base-eds-notebook:x86_64-ubuntu-24.04-nightly"
       notebook-image:  *o-notebook-image
 
   eds-ocaml-notebook-release:

--- a/eds-ocaml-notebook/config/default.opam.locked
+++ b/eds-ocaml-notebook/config/default.opam.locked
@@ -7,9 +7,9 @@ bug-reports: "https://github.com/aphp/jupyter-eds-notebooks"
 synopsis: "Base OPAM packages for the OCAML Jupyter Kernel"
 description: "Base OPAM packages for the OCAML Jupyter Kernel"
 depends: [
-  "ocaml" {< "5.0.0"} #Pining down to OCAML 4 because OCAML 5 is not supported yet -> https://github.com/akabe/ocaml-jupyter/issues/202
+  "ocaml" 
   "base"
   "base-bytes"
-  "jupyter" {>= "2.8.3"} #Forcing latest jupyter kernel version to let OPAM handle the dependency tree as the Kernel has last been updated in 2023.
+  "jupyter" {>= "2.20.0"} #Forcing latest jupyter kernel version to fixe CVE-2026-44727.
   "astring"
 ]


### PR DESCRIPTION
* Modify dependencies in default.opam.locked

Updated OCaml and Jupyter dependencies in the OPAM lock file.

* Update jupyter dependency to version >= 2.20.0

Forcing latest jupyter kernel version to fix CVE-2026-44727.

* Rename and update eds-ocaml-notebook job

Renamed 'eds-ocaml-notebook-dev' to 'eds-ocaml-notebook-snapshot' and updated its configuration.

* Fix indentation and formatting in CI workflow YAML

* Update dependency for eds-ocaml-notebook-snapshot

* Test building ocaml-nightly from base-nightly

* Fix build command to pass all build arguments

* Try ignoring fake secret in the file fake_service_account.json

* Try to skip the file fake_service_account.json

* Update CI workflow to use main branch

---------